### PR TITLE
vec should be with the vec arrow

### DIFF
--- a/include/cmds.tex
+++ b/include/cmds.tex
@@ -13,7 +13,7 @@
 %\newcommand{\RR}{\mathbbm{R}}
 %\newcommand{\CC}{\mathbbm{C}}
 
-
+\newcommand{\xcaption}[2]{\caption[#1]{\textbf{#1:} #2}}
 
 
 


### PR DESCRIPTION
boldsymbol for vectors is nice in some cases, but not for educational purposes in the beginners lab courses.
Especially in graphics it is confusing otherwise.
